### PR TITLE
MYSQL Promises 

### DIFF
--- a/helpers/inquirer.js
+++ b/helpers/inquirer.js
@@ -34,15 +34,15 @@ class Prompts {
             console.log(response.initOption)
             switch(response.initOption) {
                 case `View all departments`:
-                    dbFunc.allDepartments();
+                    dbFunc.showAll(department);
                     this.init();
                     break;
                 case `View all roles`:
-                    // dbFunc.allRoles
+                    dbFunc.showAll(role);
                     this.init();
                     break;
                 case `View all employees`:
-                    // dbFunc.allEmployees
+                    dbFunc.showAll(employee);
                     this.init();
                     break;
                 case `Add a department`:

--- a/helpers/inquirer.js
+++ b/helpers/inquirer.js
@@ -73,8 +73,6 @@ class Prompts {
         })
     }
     addRole() {
-
-        // dbFunc.allDepartments polymorph
         let departments = [];
 
         const callInfo = new Promise((resolve, reject) => {
@@ -82,68 +80,81 @@ class Prompts {
         });
         callInfo.then((response) => {
             departments = response;
-            console.log(departments);
-        inquirer
-        .prompt([
-            {
-                message: `Enter the name of the new role:`,
-                name: `newRoleName`
-            },
-            {
-                message: `Enter the salary of the new role:`,
-                name: `newRoleSalary`
-            },
-            {
-                type: 'list',
-                choices: departments,
-                message: `Enter the department the role belongds to:`,
-                name: `newRoleDep`
-            }
-        ])
-        .then((response) => {
-            console.log(`Initialized addition of ${response.newRoleName}`);
+            inquirer
+            .prompt([
+                {
+                    message: `Enter the name of the new role:`,
+                    name: `newRoleName`
+                },
+                {
+                    message: `Enter the salary of the new role:`,
+                    name: `newRoleSalary`
+                },
+                {
+                    type: 'list',
+                    choices: departments,
+                    loop: false,
+                    message: `Enter the department the role belongds to:`,
+                    name: `newRoleDep`
+                }
+            ])
+            .then((response) => {
+                console.log(`Initialized addition of ${response.newRoleName}`);
             // dbFunc.addRole(response);
             // Deconstruct in function
-            this.init();
-        })
+                this.init();
+            })
         });
     }
     addEmployee() {
-        // First name, last name, role (array), employee's manager (none, array),
 
-        const testRoles = [`Stocker`, `Baker`, `Meat Cutter`, `Deli chef`];
-        // dbFunc.allRoles() polymorph
-        const testManagers = [`None`, `John`, `Kyle`, `May`, `Blake`];
-        // dbFunc.allEmployees() polymorph
+        let roles = [];
+        let managers = [];
 
-        inquirer
-        .prompt([
-            {
-                message: `Enter the new employee's first name:`,
-                name: `newEmpFN`
-            },
-            {
-                message: `Enter the new employee's last name:`,
-                name: `newEmpLN`
-            },
-            {
-                type: 'list',
-                choices: testRoles,
-                message: `Enter the new employee's role:`,
-                name: `newEmpRole`
-            },
-            {
-                type: 'list',
-                choices: testManagers,
-                message: `Enter the new employee's manager if they have one:`,
-                name: `newEmpManager`
-            }
-        ])
-        .then((response) => {
-            console.log(response);
-            // dbFunc.addEmployee(response);
-            this.init();
-        })
+        const callRoles = new Promise((resolve, reject) => {
+            resolve(dbFunc.showAll('role', true));
+        });
+        const callManager = new Promise((resolve, reject) => {
+            resolve(dbFunc.showAll('employee', true));
+        });
+
+        Promise.all([callRoles, callManager]).then((response) => {
+
+            roles = response[0];
+            managers = response[1];
+            managers.unshift('None');
+
+            inquirer
+            .prompt([
+                {
+                    message: `Enter the new employee's first name:`,
+                    name: `newEmpFN`
+                },
+                {
+                    message: `Enter the new employee's last name:`,
+                    name: `newEmpLN`
+                },
+                {
+                    type: 'list',
+                    choices: roles,
+                    loop: false,
+                    message: `Enter the new employee's role:`,
+                    name: `newEmpRole`
+                },
+                {
+                    type: 'list',
+                    choices: managers,
+                    loop: false,
+                    message: `Enter the new employee's manager if they have one:`,
+                    name: `newEmpManager`
+                }
+            ])
+            .then((response) => {
+                console.log(response);
+                // dbFunc.addEmployee(response);
+                this.init();
+            })
+        });
     }
     updateEmpRole() {
         // All employees, which role would you like to assign 

--- a/helpers/inquirer.js
+++ b/helpers/inquirer.js
@@ -34,8 +34,8 @@ class Prompts {
             console.log(response.initOption)
             switch(response.initOption) {
                 case `View all departments`:
-                    dbFunc.showAll('department');
-                    this.init();
+                    dbFunc.showAll('department')
+                    .then(this.init());
                     break;
                 case `View all roles`:
                     dbFunc.showAll('role');

--- a/helpers/inquirer.js
+++ b/helpers/inquirer.js
@@ -115,7 +115,7 @@ class Prompts {
             resolve(dbFunc.showAll('role', true));
         });
         const callManager = new Promise((resolve, reject) => {
-            resolve(dbFunc.showAll('employee', true));
+            resolve(dbFunc.showAll('employee', true, true));
         });
 
         Promise.all([callRoles, callManager]).then((response) => {

--- a/helpers/inquirer.js
+++ b/helpers/inquirer.js
@@ -34,15 +34,15 @@ class Prompts {
             console.log(response.initOption)
             switch(response.initOption) {
                 case `View all departments`:
-                    dbFunc.showAll(department);
+                    dbFunc.showAll('department');
                     this.init();
                     break;
                 case `View all roles`:
-                    dbFunc.showAll(role);
+                    dbFunc.showAll('role');
                     this.init();
                     break;
                 case `View all employees`:
-                    dbFunc.showAll(employee);
+                    dbFunc.showAll('employee');
                     this.init();
                     break;
                 case `Add a department`:
@@ -169,6 +169,7 @@ class Prompts {
     }
 }
 
-// Prompts.init();
+const prompts = new Prompts;
+prompts.init();
 
 module.exports = Prompts;

--- a/helpers/inquirer.js
+++ b/helpers/inquirer.js
@@ -26,6 +26,8 @@ class Prompts {
                 `Add an employee`,
                 `Update and employee role`
                 ],
+                pageSize: 5,
+                loop: false,
                 message: `What would you like to do?`,
                 name: `initOption`
             }
@@ -73,8 +75,14 @@ class Prompts {
     addRole() {
 
         // dbFunc.allDepartments polymorph
-        const testDepartments = [`Bakery`, `Produce`, `Meat`, `Deli`];
+        let departments = [];
 
+        const callInfo = new Promise((resolve, reject) => {
+            resolve(dbFunc.showAll('department', true));
+        });
+        callInfo.then((response) => {
+            departments = response;
+            console.log(departments);
         inquirer
         .prompt([
             {
@@ -87,7 +95,7 @@ class Prompts {
             },
             {
                 type: 'list',
-                choices: testDepartments,
+                choices: departments,
                 message: `Enter the department the role belongds to:`,
                 name: `newRoleDep`
             }
@@ -98,6 +106,7 @@ class Prompts {
             // Deconstruct in function
             this.init();
         })
+        });
     }
     addEmployee() {
         // First name, last name, role (array), employee's manager (none, array),
@@ -171,9 +180,10 @@ showAllPromise = choice => {
         resolve(dbFunc.showAll(choice));
     });
     callInfo.then((response) => {
-        console.log(response);
-        console.log('Success!');
-        this.init();
+        console.table(response);
+        console.log('Promise resolved!');
+        const prompts = new Prompts;
+        prompts.init();
     });
 }
 

--- a/helpers/inquirer.js
+++ b/helpers/inquirer.js
@@ -34,8 +34,16 @@ class Prompts {
             console.log(response.initOption)
             switch(response.initOption) {
                 case `View all departments`:
-                    dbFunc.showAll('department')
-                    .then(this.init());
+
+                    const promise1 = new Promise((resolve, reject) => {
+                        resolve(dbFunc.showAll('employee'));
+                    });
+                    promise1.then((response) => {
+                        console.log(response);
+                        console.log('Success!');
+                        this.init();
+                    });
+
                     break;
                 case `View all roles`:
                     dbFunc.showAll('role');

--- a/helpers/inquirer.js
+++ b/helpers/inquirer.js
@@ -34,24 +34,13 @@ class Prompts {
             console.log(response.initOption)
             switch(response.initOption) {
                 case `View all departments`:
-
-                    const promise1 = new Promise((resolve, reject) => {
-                        resolve(dbFunc.showAll('employee'));
-                    });
-                    promise1.then((response) => {
-                        console.log(response);
-                        console.log('Success!');
-                        this.init();
-                    });
-
+                    showAllPromise('department')
                     break;
                 case `View all roles`:
-                    dbFunc.showAll('role');
-                    this.init();
+                    showAllPromise('role')
                     break;
                 case `View all employees`:
-                    dbFunc.showAll('employee');
-                    this.init();
+                    showAllPromise('employee');
                     break;
                 case `Add a department`:
                     this.addDepartment();
@@ -175,6 +164,17 @@ class Prompts {
             this.init();
         })
     }
+}
+
+showAllPromise = choice => {
+    const callInfo = new Promise((resolve, reject) => {
+        resolve(dbFunc.showAll(choice));
+    });
+    callInfo.then((response) => {
+        console.log(response);
+        console.log('Success!');
+        this.init();
+    });
 }
 
 const prompts = new Prompts;

--- a/helpers/inquirer.js
+++ b/helpers/inquirer.js
@@ -34,7 +34,7 @@ class Prompts {
             console.log(response.initOption)
             switch(response.initOption) {
                 case `View all departments`:
-                    // dbFunc.allDepartments
+                    dbFunc.allDepartments();
                     this.init();
                     break;
                 case `View all roles`:

--- a/helpers/mysql.js
+++ b/helpers/mysql.js
@@ -24,16 +24,29 @@ const db = mysql.createConnection(
 
 class DBFunc {
     async showAll(table, returnArray) { 
-        let sendBack;
+        let sendBack = [];
         try {
             const results = await db.query(`SELECT * FROM ${table}`);
-            sendBack = results[0];
-            // console.log(results[0]);
+            const data = results[0];
+            if(returnArray) {
+                let param;
+                if (table == 'department') {param = 'name'
+                } else if (table == 'role') {param = 'title'
+                } else {param = 'first_name'};
+
+                for (let i = 0; i < results.length; i++) {
+                    sendBack[i] = data[i][param];
+                        // Kind of gross that I can't just edit 'param' to do this but eh, it's only one more line.
+                        if (table == 'employee') { sendBack[i] += ` ${results[i]['last_name']}` };
+                };
+                return sendBack;
+            } else {
+                return data;
+            }
         } catch (error) {
             console.error(error)
         }
-        // console.log(sendBack);
-        return sendBack;
+        // return sendBack;
     }
 }
 

--- a/helpers/mysql.js
+++ b/helpers/mysql.js
@@ -28,16 +28,17 @@ class DBFunc {
         try {
             const results = await db.query(`SELECT * FROM ${table}`);
             const data = results[0];
+            
             if(returnArray) {
                 let param;
                 if (table == 'department') {param = 'name'
                 } else if (table == 'role') {param = 'title'
                 } else {param = 'first_name'};
 
-                for (let i = 0; i < results.length; i++) {
+                for (let i = 0; i < data.length; i++) {
                     sendBack[i] = data[i][param];
                         // Kind of gross that I can't just edit 'param' to do this but eh, it's only one more line.
-                        if (table == 'employee') { sendBack[i] += ` ${results[i]['last_name']}` };
+                        if (table == 'employee') { sendBack[i] += ` ${data[i]['last_name']}` };
                 };
                 return sendBack;
             } else {

--- a/helpers/mysql.js
+++ b/helpers/mysql.js
@@ -29,8 +29,31 @@ class DBFunc {
             const results = await db.query(`SELECT * FROM ${table}`);
             sendBack = results[0];
             // console.log(results[0]);
-        
-        // const results = await db.query(`SELECT * FROM ${table}`, function (err, results) {
+        } catch (error) {
+            console.error(error)
+        }
+        // console.log(sendBack);
+        return sendBack;
+    }
+}
+
+const dbFunc = new DBFunc;
+// dbFunc.showAll('employee').then(console.log('Promise fufilled'));
+// console.log('Fufilled 2')
+// const grape = dbFunc.showAll('employee');
+// console.log(grape);
+
+// const promise1 = new Promise((resolve, reject) => {
+//     resolve(dbFunc.showAll('employee'));
+// });
+// promise1.then((response) => {
+//     console.log(response);
+//     this.init();
+// });
+
+module.exports = DBFunc;
+
+ // const results = await db.query(`SELECT * FROM ${table}`, function (err, results) {
         //     if (err) {
         //         console.log(err);
         //     }
@@ -56,27 +79,3 @@ class DBFunc {
         //     };
         //     console.log(thrownObject);
         // });
-        } catch (error) {
-            console.error(error)
-        }
-        // console.log(sendBack);
-        return sendBack;
-    }
-}
-
-const dbFunc = new DBFunc;
-// dbFunc.showAll('employee').then(console.log('Promise fufilled'));
-// console.log('Fufilled 2')
-// const grape = dbFunc.showAll('employee');
-// console.log(grape);
-
-const promise1 = new Promise((resolve, reject) => {
-    resolve(dbFunc.showAll('employee'));
-});
-
-promise1.then((response) => {
-    console.log(response);
-    console.log('YAY!')
-});
-
-module.exports = DBFunc;

--- a/helpers/mysql.js
+++ b/helpers/mysql.js
@@ -1,5 +1,7 @@
 const mysql = require('mysql2');
 
+require('dotenv').config({ path: '../.env' });
+
 // View all departments (polymorph to send back an array)
 // View all roles (polymorph to send back an array)
 // View all employees (polymorph to send back an array, polymorph to filter ONLY managers)
@@ -7,6 +9,16 @@ const mysql = require('mysql2');
 // Add a role
 // Add an employee
 // Update and employee role
+
+const db = mysql.createConnection(
+    {
+        host: 'localhost',
+        user: process.env.DB_USER,
+        password: process.env.DB_PASSWORD,
+        database: process.env.DB_NAME
+    },
+    console.log(`Connect to the bigstore_db database.`)
+);
 
 class DBFunc {
 

--- a/helpers/mysql.js
+++ b/helpers/mysql.js
@@ -1,5 +1,5 @@
 const mysql = require('mysql2');
-
+const cTable = require('console.table');
 require('dotenv').config({ path: '../.env' });
 
 // View all departments (polymorph to send back an array)
@@ -21,7 +21,27 @@ const db = mysql.createConnection(
 );
 
 class DBFunc {
-
+    allDepartments(returnArray) {
+        db.query('SELECT * FROM department', function (err, results) {
+            if (err) {
+                console.log(err);
+            }
+            // If called for the addRole() func in inquirer.js
+            if (returnArray) {
+                let departments = [];
+                for (let i = 0; i < results.length; i++) {
+                    departments[i] = results[i].name;
+                };
+                return departments;
+            } else {
+                // Otherwise just print the results for `View all departments`
+                console.table(results);
+            };
+          });
+    };
 }
+
+const dbFunc = new DBFunc;
+dbFunc.allDepartments(true);
 
 module.exports = DBFunc;

--- a/helpers/mysql.js
+++ b/helpers/mysql.js
@@ -17,48 +17,66 @@ const dbConfig = {
     database: process.env.DB_NAME
 }
 
+const db = mysql.createConnection(
+    dbConfig, 
+    console.log(`Connected to ${dbConfig.database}`)
+).promise();
+
 class DBFunc {
-    async showAll(table, returnArray) {
-        const db = mysql.createConnection(
-            dbConfig, 
-            console.log(`Connected to ${dbConfig.database}`)
-        );
+    async showAll(table, returnArray) { 
+        let sendBack;
+        try {
+            const results = await db.query(`SELECT * FROM ${table}`);
+            sendBack = results[0];
+            // console.log(results[0]);
         
-        db.query(`SELECT * FROM ${table}`, function (err, results) {
-            if (err) {
-                console.log(err);
-            }
-            // If called for the addRole(), addEmployee(), or updateRole func in inquirer.js
-            if (returnArray) {
-                let sendBack = [];
+        // const results = await db.query(`SELECT * FROM ${table}`, function (err, results) {
+        //     if (err) {
+        //         console.log(err);
+        //     }
+        //     // If called for the addRole(), addEmployee(), or updateRole func in inquirer.js
+        //     if (returnArray) {
+        //         let sendBack = [];
 
-                let param;
-                if (table == 'department') { param = 'name';
-                } else if (table == 'role') {param = 'title';
-                } else {param = 'first_name'};
+        //         let param;
+        //         if (table == 'department') { param = 'name';
+        //         } else if (table == 'role') {param = 'title';
+        //         } else {param = 'first_name'};
 
-                for (let i = 0; i < results.length; i++) {
-                    sendBack[i] = results[i][param];
-                        // Kind of gross that I can't just edit 'param' to do this but eh, it's only one more line.
-                        if (table = 'employee') { sendBack[i] += ` ${results[i]['last_name']}` };
-                };
-                // console.log(sendBack);
-                // thrownObject = sendBack;
-                console.log(thrownObject)
-                
-            } else {
-                // console.table(results);
-                thrownObject = results;
-                // console.log(thrownObject);
-            };
-            console.log(thrownObject);
-        });
-        // console.log(thrownObject);
-        // return thrownObject;
-    };
+        //         for (let i = 0; i < results.length; i++) {
+        //             sendBack[i] = results[i][param];
+        //                 // Kind of gross that I can't just edit 'param' to do this but eh, it's only one more line.
+        //                 if (table = 'employee') { sendBack[i] += ` ${results[i]['last_name']}` };
+        //         };
+        //         // thrownObject = sendBack;
+        //     } else {
+        //         // console.table(results);
+        //         thrownObject = results;
+        //         // console.log(thrownObject);
+        //     };
+        //     console.log(thrownObject);
+        // });
+        } catch (error) {
+            console.error(error)
+        }
+        // console.log(sendBack);
+        return sendBack;
+    }
 }
 
 const dbFunc = new DBFunc;
-console.table(dbFunc.showAll('employee'));
+// dbFunc.showAll('employee').then(console.log('Promise fufilled'));
+// console.log('Fufilled 2')
+// const grape = dbFunc.showAll('employee');
+// console.log(grape);
+
+const promise1 = new Promise((resolve, reject) => {
+    resolve(dbFunc.showAll('employee'));
+});
+
+promise1.then((response) => {
+    console.log(response);
+    console.log('YAY!')
+});
 
 module.exports = DBFunc;

--- a/helpers/mysql.js
+++ b/helpers/mysql.js
@@ -21,20 +21,48 @@ const db = mysql.createConnection(
 );
 
 class DBFunc {
-    allDepartments(returnArray) {
-        db.query('SELECT * FROM department', function (err, results) {
+    // allDepartments(returnArray) {
+    //     db.query('SELECT * FROM department', function (err, results) {
+    //         if (err) {
+    //             console.log(err);
+    //         }
+    //         // If called for the addRole() func in inquirer.js
+    //         if (returnArray) {
+    //             let departments = [];
+    //             for (let i = 0; i < results.length; i++) {
+    //                 departments[i] = results[i].name;
+    //             };
+    //             return departments;
+    //         } else {
+    //             // Otherwise just print the results for `View all departments`
+    //             console.table(results);
+    //         };
+    //       });
+    // };
+    showAll(table, returnArray) {
+        db.query(`SELECT * FROM ${table}`, function (err, results) {
             if (err) {
                 console.log(err);
             }
-            // If called for the addRole() func in inquirer.js
+            // If called for the addRole(), addEmployee(), or updateRole func in inquirer.js
             if (returnArray) {
-                let departments = [];
+                let sendBack = [];
+
+                let param;
+                if (table == 'department') { param = 'name';
+                } else if (table == 'role') {param = 'title';
+                } else {param = 'first_name'};
+
                 for (let i = 0; i < results.length; i++) {
-                    departments[i] = results[i].name;
+                    sendBack[i] = results[i][param];
+                        // Kind of gross that I can't just edit 'param' to do this but eh, it's only one more line.
+                        if (table = 'employee') { sendBack[i] += ` ${results[i]['last_name']}` };
                 };
-                return departments;
+                
+                console.log(sendBack);
+                return sendBack;
             } else {
-                // Otherwise just print the results for `View all departments`
+                // Otherwise just print the results for `View all {table}`
                 console.table(results);
             };
           });
@@ -42,6 +70,6 @@ class DBFunc {
 }
 
 const dbFunc = new DBFunc;
-dbFunc.allDepartments(true);
+dbFunc.showAll('employee');
 
 module.exports = DBFunc;

--- a/helpers/mysql.js
+++ b/helpers/mysql.js
@@ -23,12 +23,12 @@ const db = mysql.createConnection(
 ).promise();
 
 class DBFunc {
-    async showAll(table, returnArray) { 
+    async showAll(table, returnArray, managerCall) { 
         let sendBack = [];
         try {
             const results = await db.query(`SELECT * FROM ${table}`);
             const data = results[0];
-            
+
             if(returnArray) {
                 let param;
                 if (table == 'department') {param = 'name'
@@ -40,6 +40,7 @@ class DBFunc {
                         // Kind of gross that I can't just edit 'param' to do this but eh, it's only one more line.
                         if (table == 'employee') { sendBack[i] += ` ${data[i]['last_name']}` };
                 };
+
                 return sendBack;
             } else {
                 return data;
@@ -48,6 +49,9 @@ class DBFunc {
             console.error(error)
         }
         // return sendBack;
+    }
+    async addRole(newRole) {
+        const {newRoleName, newRoleSalary, newRoleDep} = newRole;
     }
 }
 

--- a/helpers/mysql.js
+++ b/helpers/mysql.js
@@ -10,36 +10,20 @@ require('dotenv').config({ path: '../.env' });
 // Add an employee
 // Update and employee role
 
-const db = mysql.createConnection(
-    {
-        host: 'localhost',
-        user: process.env.DB_USER,
-        password: process.env.DB_PASSWORD,
-        database: process.env.DB_NAME
-    },
-    console.log(`Connect to the bigstore_db database.`)
-);
+const dbConfig = {
+    host: 'localhost',
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME
+}
 
 class DBFunc {
-    // allDepartments(returnArray) {
-    //     db.query('SELECT * FROM department', function (err, results) {
-    //         if (err) {
-    //             console.log(err);
-    //         }
-    //         // If called for the addRole() func in inquirer.js
-    //         if (returnArray) {
-    //             let departments = [];
-    //             for (let i = 0; i < results.length; i++) {
-    //                 departments[i] = results[i].name;
-    //             };
-    //             return departments;
-    //         } else {
-    //             // Otherwise just print the results for `View all departments`
-    //             console.table(results);
-    //         };
-    //       });
-    // };
-    showAll(table, returnArray) {
+    async showAll(table, returnArray) {
+        const db = mysql.createConnection(
+            dbConfig, 
+            console.log(`Connected to ${dbConfig.database}`)
+        );
+        
         db.query(`SELECT * FROM ${table}`, function (err, results) {
             if (err) {
                 console.log(err);
@@ -58,18 +42,23 @@ class DBFunc {
                         // Kind of gross that I can't just edit 'param' to do this but eh, it's only one more line.
                         if (table = 'employee') { sendBack[i] += ` ${results[i]['last_name']}` };
                 };
+                // console.log(sendBack);
+                // thrownObject = sendBack;
+                console.log(thrownObject)
                 
-                console.log(sendBack);
-                return sendBack;
             } else {
-                // Otherwise just print the results for `View all {table}`
-                console.table(results);
+                // console.table(results);
+                thrownObject = results;
+                // console.log(thrownObject);
             };
-          });
+            console.log(thrownObject);
+        });
+        // console.log(thrownObject);
+        // return thrownObject;
     };
 }
 
 const dbFunc = new DBFunc;
-dbFunc.showAll('employee');
+console.table(dbFunc.showAll('employee'));
 
 module.exports = DBFunc;

--- a/index.js
+++ b/index.js
@@ -6,4 +6,16 @@ const DBFunc = require('./helpers/mysql.js');
 
 const prompts = new Prompts;
 
+require('dotenv').config({ path: './.env' });
+
+// const db = mysql.createConnection(
+//     {
+//         host: 'localhost',
+//         user: process.env.DB_USER,
+//         password: process.env.DB_PASSWORD,
+//         database: process.env.DB_NAME
+//     },
+//     console.log(`Connect to the bigstore_db database.`)
+// );
+
 prompts.init();


### PR DESCRIPTION
Debugged and found a way to promise a MYSQL database request before writing the response to console. The promise is displayed to console, a debug confirm message is displayed, and then init() is ran again to return to the main menu.

For Inquirer prompts that need db calls to form an array, promises are arranged at the beginning of the prompt to declare the multiple choices.

For next time: finish requests for updateEmpRole(), add logic to mysql.js to return only managers (not just manager_id 'null' responses, but employees who are actively managing another employee). After that then add logic in mysql to insert to tables and update emp data.

After that, do some extra credit work!